### PR TITLE
Layout

### DIFF
--- a/vreco-project/public/index.html
+++ b/vreco-project/public/index.html
@@ -50,7 +50,7 @@
                     <li>
                         <div class="form-group">
                             <label for="name">Vtuberの名前</label>
-                            <input type="text" class="form-control" name="name" id="form_name" placeholder="（例）キズナアイ">
+                            <input required type="text" class="form-control" name="name" id="form_name" placeholder="（例）キズナアイ">
                         </div>
                     </li>
 
@@ -157,6 +157,17 @@
                     </li>
                 </ol>
             </form>
+            <div class="container" id="tweet-area">
+                <button type="button" class="btn btn-outline-primary" onclick=setTweetButton(acquireForm())>生成</button>
+            </div>
+
+            <div class="container" id="tweet-area2">
+                <p>プレビュー<span  style="border: solid 1px darkgray;width: 300px;height: 80px;" id="preview">ここに表示されるかもしれません</span>　
+                <a id="tweetbutton" href="https://twitter.com/share?url=http%3A%2F%2Fvreco-542cc.firebaseapp.com
+                &text=VRECO%20-%20%E6%8E%A8%E3%81%97%E3%81%94%E3%81%A8%E6%94%AF%E6%8F%B4%E3%82%B5%E3%82%A4%E3%83%88"
+                 class="btn btn-primary" target="_blank">tweet</a></p>
+                </div>
+            </div>
             <div>最後の質問です。</div>
         </main>
 
@@ -165,7 +176,7 @@
         <!--下2行のLINE共有ボタンは、公開後にしか確認できない仕様です。-->
         <!-- <div class="line-it-button" data-lang="ja" data-type="share-a" data-ver="3" data-url="http://vreco-542cc.firebaseapp.com" data-color="default" data-size="small" data-count="false" style="display: none;"></div>
         <script src="https://d.line-scdn.net/r/web/social-plugin/js/thirdparty/loader.min.js" async="async" defer="defer"></script><br> -->
-        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script><br>
+        <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-show-count="false">Tweet</a><script src="https://platform.twitter.com/widgets.js" charset="utf-8"></script><br>
         © All rights reserved by VRECO運営
       </footer>
 

--- a/vreco-project/public/script.js
+++ b/vreco-project/public/script.js
@@ -12,6 +12,9 @@ function inputsInit(choices,qSentence){
             // 設問ブロックを包むdivを生成
             var liParEl = document.createElement('li');//番号つきリストに加える要素を生成
             var divEl = document.createElement('div');
+            
+            // TODO:elementにIDを大問名で追加する。後のエラーチェックでクラスを追加するのに使おうと思っている
+            
             divEl.className = 'form-group';
         
             var tmpEl = document.createElement('p');
@@ -26,6 +29,7 @@ function inputsInit(choices,qSentence){
                     const sub_element = tmp_obj[sub_key];
                     var inputEl = document.createElement('input');
                     // inputEl.className = 'form-check-input'　//TODO::CSSクラスを追記
+                    //もしかしたら、しないほうがいいかも
                     inputEl.type = 'radio';
                     inputEl.id=sub_key;
                     inputEl.name = key;//name属性には親要素と同じ内容を書き込む
@@ -63,48 +67,115 @@ function inputsInit(choices,qSentence){
 *　返り値：回答内容を格納した配列[]
 */
 function acquireForm(){
-    var form = document.forms[0];
-    var vname = form.name.value;
-    var url = form.url.value;
-    var inputArr = Object.keys(choices);
-    //questions.jsにて定義したオブジェクトからキー名を取得
-    //name属性に使用してるため実用可能
-    //仕様を変更する場合は、elements全てforループに巻き込んでvalueを取得していく形に書き換え
-    var anserArr=[vname,url];
+    const form = document.forms[0];
+    let vname = form.name.value;
+    let url = form.url.value;
 
-    for (let i = 0; i < inputArr.length; i++) {
-        form[inputArr[i]].forEach(element => {
+    //questions.jsにて定義したオブジェクトからキー名を取得
+    const inputIndex = Object.keys(choices);
+    //name属性に使用してるため実用可能
+
+    let anserArr = [];
+    for (let i = 0; i < inputIndex.length; i++) {
+        let exist = false;
+        form[inputIndex[i]].forEach(element => {
             if(element.checked){
-                anserArr.push(element.value);
+                anserArr.push(element.id);
+                exist=true;
             }
         });
+
+        /*
+        //TODO：なにもヒットしなかった場合、エラーを返したい
+        //エラーがある座標すべてに対してエラーを表現するcssクラスを追加することによって
+        if (!exist) {
+            //要素を同定し、適した範囲にcssクラスを追加する
+        }
+        */
     }
 
-    console.log(vname,anserArr,url);
-    return anserArr;
+
+    //TODO:anserArrをメソッドに投げて、tweetに使う文字列に変換したい。。。
+
+
+    var anserObj={name:vname,url:url,text:anserArr};
+    return anserObj;
 }
 
 
 
 /*
 *　取り込んだ内容を文面に変換するメソッド（コールバックで）
+*　src = [Vの名前、URL、選択されているvalue]
+*　最終的な文面→　……？？？
 */
+function henkan(src){
+    var vname = src[0];
+    var url = src[1]?src[1]:null; //urlが入っていればそのデータを、入ってなければnullを変数に入れる
+    var tmp1;
+    return tmp;
+}
+
+
+
+
 
 /*
 *　文面をtweetタグへ変換し、tweetボタンを生成・上書きするメソッド
+*　tweetボタンにぶち込む文面を引数に入れてメソッドを呼び出す
+*　参考url = https://qiita.com/lovesaemi/items/d4f296b6b1d5158d2fea
+// 任意のタイミングで呼べば狙ったとおりのテキストのボタンつくれる
+// 引数増やしていろいろやってもよいですね。
+*
+* anserObj = {name,url,anserArr=[],text,hashtags}
 */
+function setTweetButton(anserObj){
+    var tw = document.getElementById('tweet-area'); //既存のボタン消す
+    while (tw.firstChild) tw.removeChild(tw.firstChild);
 
 
-var result = new Promise(function(resolve){
+    // htmlでスクリプトを読んでるからtwttがエラーなく呼べる
+    // オプションは公式よんで。
+    // createShareButton(url,targetElement,options);
+    twttr.widgets.createShareButton(
+      "vreco-542cc.firebaseapp.com",//tweet本文に入るurlとは別のもの
+      tw,//    document.getElementById('tweet-area')
+      {
+        size: "large", //ボタンはでかく
+        text: anserObj.name + anserObj.text + " サンプルテキスト",//anserObj.text, // 狙ったテキスト
+        hashtags: anserObj.hashtags?anserObj.hashtags:"", // ハッシュタグ
+        url: anserObj.url//anserObj.url // URL
+      }
+    ).then(function(){
+        let btn = document.createElement("Button");
+        btn.type="button";
+        btn.className="btn btn-outline-primary";
+        btn.textContent="再生成";
+        btn.addEventListener('click',setTweetButton(acquireForm()))
+        tw.appendChild(btn);
+    }
+    );
+}
+//参考url http://westplain.sakuraweb.com/translate/twitter/Documentation/Twitter-for-Websites/Tweet-Button/JavaScript-Factory-Function.cgi
+// http://westplain.sakuraweb.com/translate/twitter/Documentation/Twitter-for-Websites/Tweet-Button/Parameter-Reference.cgi
 
-});
+function updateTweetbutton(){
+    const anserObj = acquireForm();
+    var tmp = document.getElementById('tweetbutton')
+    
+    let url = encodeURIComponent("http://vreco-542cc.firebaseapp.com");
+    tmp.href = "https://twitter.com/share?url=" + url + "&text=" + encodeURIComponent(anserObj.name + anserObj.text);
+
+    document.getElementById('preview').textContent=anserObj.name + anserObj.text + "仮の文面を表示しています";
+}
+
 
 /*
 *　読み込み完了時にメソッド点火
 *　choices,questionSentenceはquestion.jsで宣言したオブジェクト
 */
-
-
-
 inputsInit(choices,questionSentence);
-// acquireForm();
+
+//formを操作するたびにtweetのソースを上書きするイベントリスナ追加
+document.forms[0].addEventListener("change",updateTweetbutton)
+


### PR DESCRIPTION
tweetタグを動的に生成するメソッドを作成
ともなってhtmlのTwitter widget scriptタグからasync属性を削除（widgetを読み込み終わってから自前のscriptを実行するために非同期処理を解除するため）
htmlにプレビューの枠を追加

ツイートボタンの生成に関しては、公式widgetでツイートボタンを読みだすものと、
htmlクエリを使って行うものと両方用意した
公式のものは公式サーバと通信してるのか何なのか、連続でボタンを押すとたまに不安定になる
なので頻繁に変更する場合は自前のボタン要素のほうが安全かもしれない


テスト可能になったので、作業内容の同期の意味でプルリク